### PR TITLE
feat: Add web search tool example and update environment configuration

### DIFF
--- a/prototype/frameworks/llamastack/.env.example
+++ b/prototype/frameworks/llamastack/.env.example
@@ -1,2 +1,7 @@
 INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct"
 LLAMA_STACK_PORT=8321
+
+OLLAMA_URL=http://localhost:11434
+
+# Websearch tool related API Keys
+TAVILY_SEARCH_API_KEY="your_tavily_search_api_key"

--- a/prototype/frameworks/llamastack/README.md
+++ b/prototype/frameworks/llamastack/README.md
@@ -117,8 +117,17 @@ Run the script:
 python code-agent.py
 ```
 ---
+## **9. Run a build in web search Agent**
 
-## **9. Run a Custom Tool Agent**
+If you wish to test around the web search tool with external web search API, you can follow the example in `tool_websearch.py`. This example modified based on exsiting web search tool from https://colab.research.google.com/github/meta-llama/llama-stack/blob/main/docs/getting_started.ipynb. Allow run it through podman follow same instruction.
+
+Run the script:
+
+```bash
+python tool_websearch.py
+```
+---
+## **10. Run a Custom Tool Agent**
 
 If you wish to add your own custom tool, you can follow the example in `custom-tool.py`. This example defines a simple calculator tool to perform arithmetic operations such as add, subtract, multiply and divide.
 
@@ -128,7 +137,7 @@ Run the script:
 python custom-tool.py
 ```
 
-## **10. Debugging Common Issues**
+## **11. Debugging Common Issues**
 **Check if Podman is Running:**
 ```bash
 podman ps

--- a/prototype/frameworks/llamastack/scripts/tool_websearch.py
+++ b/prototype/frameworks/llamastack/scripts/tool_websearch.py
@@ -1,0 +1,71 @@
+from llama_stack_client.lib.agents.agent import Agent
+from llama_stack_client.lib.agents.event_logger import EventLogger
+from llama_stack_client.types.agent_create_params import AgentConfig
+from termcolor import cprint
+import os
+import sys
+from dotenv import load_dotenv
+
+# Load .env file
+load_dotenv()
+
+# Access the environment variables
+inference_model = os.getenv("INFERENCE_MODEL")
+llama_stack_port = os.getenv("LLAMA_STACK_PORT")
+ollama_url = os.getenv("OLLAMA_URL")
+TAVILY_SEARCH_API_KEY = os.environ["TAVILY_SEARCH_API_KEY"]
+
+print(f"Model: {inference_model}")
+print(f"Llama Stack Port: {llama_stack_port}")
+print(f"Ollama URL: {ollama_url}")
+
+def create_http_client():
+    from llama_stack_client import LlamaStackClient
+
+    return LlamaStackClient(
+        base_url=f"http://localhost:{llama_stack_port}", # return LlamaStackClient(base_url="http://localhost:8321", timeout = 6000)
+        provider_data = {"tavily_search_api_key": os.environ['TAVILY_SEARCH_API_KEY']}  # according to https://llama-stack.readthedocs.io/en/latest/building_applications/tools.html
+    )
+
+# Initialize the Llama Stack client, choosing between library or HTTP client
+client = create_http_client()  
+
+# Register Search tool group
+# according to https://llama-stack.readthedocs.io/en/latest/building_applications/tools.html
+client.toolgroups.register( 
+    toolgroup_id="builtin::websearch",
+    provider_id="tavily-search",
+    args={"max_results": 5},
+)
+
+print(client.toolgroups.list())
+
+# Below is modified from websearch example from https://colab.research.google.com/github/meta-llama/llama-stack/blob/main/docs/getting_started.ipynb
+agent_config = AgentConfig(
+    model=os.getenv("INFERENCE_MODEL"),
+    instructions="You are a helpful web search assistant, you can use websearch tool for unknown queries.",
+    toolgroups=["builtin::websearch"],
+    input_shields=[],
+    output_shields=[],
+    enable_session_persistence=False,
+)
+agent = Agent(client, agent_config)
+user_prompts = [
+    "Hello",
+    "Which teams played in the NBA western conference finals of 2024",
+]
+
+session_id = agent.create_session("test-session")
+for prompt in user_prompts:
+    cprint(f"User> {prompt}", "green")
+    response = agent.create_turn(
+        messages=[
+            {
+                "role": "user",
+                "content": prompt,
+            }
+        ],
+        session_id=session_id,
+    )
+    for log in EventLogger().log(response):
+        log.print()

--- a/prototype/frameworks/llamastack/scripts/tool_websearch.py
+++ b/prototype/frameworks/llamastack/scripts/tool_websearch.py
@@ -13,7 +13,6 @@ load_dotenv()
 inference_model = os.getenv("INFERENCE_MODEL")
 llama_stack_port = os.getenv("LLAMA_STACK_PORT")
 ollama_url = os.getenv("OLLAMA_URL")
-TAVILY_SEARCH_API_KEY = os.environ["TAVILY_SEARCH_API_KEY"]
 
 print(f"Model: {inference_model}")
 print(f"Llama Stack Port: {llama_stack_port}")
@@ -24,7 +23,7 @@ def create_http_client():
 
     return LlamaStackClient(
         base_url=f"http://localhost:{llama_stack_port}", # return LlamaStackClient(base_url="http://localhost:8321", timeout = 6000)
-        provider_data = {"tavily_search_api_key": os.environ['TAVILY_SEARCH_API_KEY']}  # according to https://llama-stack.readthedocs.io/en/latest/building_applications/tools.html
+        provider_data = {"tavily_search_api_key": os.environ["TAVILY_SEARCH_API_KEY"]}  # according to https://llama-stack.readthedocs.io/en/latest/building_applications/tools.html
     )
 
 # Initialize the Llama Stack client, choosing between library or HTTP client

--- a/prototype/frameworks/llamastack/scripts/tool_websearch.py
+++ b/prototype/frameworks/llamastack/scripts/tool_websearch.py
@@ -13,6 +13,7 @@ load_dotenv()
 inference_model = os.getenv("INFERENCE_MODEL")
 llama_stack_port = os.getenv("LLAMA_STACK_PORT")
 ollama_url = os.getenv("OLLAMA_URL")
+TAVILY_SEARCH_API_KEY = os.environ["TAVILY_SEARCH_API_KEY"]
 
 print(f"Model: {inference_model}")
 print(f"Llama Stack Port: {llama_stack_port}")
@@ -23,7 +24,7 @@ def create_http_client():
 
     return LlamaStackClient(
         base_url=f"http://localhost:{llama_stack_port}", # return LlamaStackClient(base_url="http://localhost:8321", timeout = 6000)
-        provider_data = {"tavily_search_api_key": os.environ["TAVILY_SEARCH_API_KEY"]}  # according to https://llama-stack.readthedocs.io/en/latest/building_applications/tools.html
+        provider_data = {"tavily_search_api_key": TAVILY_SEARCH_API_KEY}  # according to https://llama-stack.readthedocs.io/en/latest/building_applications/tools.html
     )
 
 # Initialize the Llama Stack client, choosing between library or HTTP client


### PR DESCRIPTION
This PR introduces an example for running a web search agent using an external web search API. The script tool_websearch.py is based on the existing web search tool from [Meta Llama Stack get start example](https://colab.research.google.com/github/meta-llama/llama-stack/blob/main/docs/getting_started.ipynb). This update also ensures compatibility with Podman, following the same setup instructions.

**Changes:**
Added tool_websearch.py to demonstrate web search tool integration
Updated documentation to include steps for running the script with Podman

**How to Test:**
Ensure dependencies are installed
Run the script with: `python tool_websearch.py`

**Expected Behavior:**
The script should execute successfully, utilizing the external web search API. 
![image](https://github.com/user-attachments/assets/cb228340-5c23-4422-8cb6-3c220654f7a7)
