### PR TITLE
DOCS: llama_stack_client version latest required for certain scripts

### DIFF
--- a/prototype/frameworks/llamastack/README.md
+++ b/prototype/frameworks/llamastack/README.md
@@ -10,6 +10,7 @@ Ensure you have the following installed:
 - **Python 3.10+**
 - **pip** (latest version)
 - **Ollama** ([Install Ollama](https://ollama.com/download))
+- **llama_stack_client >= 0.1.3**
 
 Verify installation:
 ```bash


### PR DESCRIPTION
Custom-tools.py requires that llama_stack_client >= 0.1.3 in order to run