### PR TITLE
Add Github community mcp server deployment files

### DIFF
--- a/prototype/frameworks/mcp/community-servers/github/build_config.yaml
+++ b/prototype/frameworks/mcp/community-servers/github/build_config.yaml
@@ -1,0 +1,32 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: github-mcp-server
+  namespace: mcp-community-servers
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: github-mcp-server
+  namespace: mcp-community-servers
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: github-mcp-server:latest
+  source:
+    git:
+      uri: https://github.com/Shreyanand/servers.git
+      ref: main
+    contextDir: "." 
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: src/github/Dockerfile
+      noCache: true
+      forcePull: true
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChange: {}
+      

--- a/prototype/frameworks/mcp/community-servers/github/deployment.yaml
+++ b/prototype/frameworks/mcp/community-servers/github/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-mcp-server
+  namespace: mcp-community-servers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: github-mcp-server
+  template:
+    metadata:
+      labels:
+        app: github-mcp-server
+    spec:
+      containers:
+      - name: github-mcp-server
+        image: image-registry.openshift-image-registry.svc:5000/mcp-community-servers/github-mcp-server:latest
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          npx -y supergateway --stdio "node dist/index.js" --port 8080
+        ports:
+        - containerPort: 8080
+        env:
+        - name: NPM_CONFIG_CACHE
+          value: /tmp/.npm
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-credentials
+              key: token
+        resources:
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+          requests:
+            cpu: "200m"
+            memory: "256Mi"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-mcp-server
+  namespace: mcp-community-servers
+spec:
+  selector:
+    app: github-mcp-server
+  ports:
+  - port: 80
+    targetPort: 8080
+---
+
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: github-mcp-server
+  namespace: mcp-community-servers
+spec:
+  to:
+    kind: Service
+    name: github-mcp-server
+  port:
+    targetPort: 8080
+    

--- a/prototype/frameworks/mcp/community-servers/github/secret.yaml
+++ b/prototype/frameworks/mcp/community-servers/github/secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-credentials
+  namespace: mcp-community-servers
+type: Opaque
+stringData:
+  # Add your PAT here
+  token: ""
+  


### PR DESCRIPTION
Note: The build config contains my fork temporarily (https://github.com/Shreyanand/servers.git) as the upstream has an uninitialized  submodule that doesn't let the git clone task finish. 

The PR also uses the supergateway project to convert stdio server to sse server.