### PR TITLE
Increase vllm context length

### DIFF
--- a/prototype/frameworks/llamastack/kubernetes/llama-stack/configmap.yaml
+++ b/prototype/frameworks/llamastack/kubernetes/llama-stack/configmap.yaml
@@ -22,7 +22,7 @@ data:
         provider_type: remote::vllm
         config:
           url: ${env.VLLM_URL}
-          max_tokens: 4096
+          max_tokens: 128000
           api_token: fake
           tls_verify: false
       - provider_id: vllm-safety

--- a/prototype/frameworks/llamastack/kubernetes/llama-stack/deployment.yaml
+++ b/prototype/frameworks/llamastack/kubernetes/llama-stack/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         - /app-config/config.yaml
         env:
         - name: VLLM_MAX_TOKENS
-          value: "4096"
+          value: "128000"
         - name: INFERENCE_MODEL
           value: meta-llama/Llama-3.2-3B-Instruct
         - name: VLLM_URL


### PR DESCRIPTION
I have been seeing `llama_stack.providers.inline.agents.meta_reference.agent_instance:600 agents: out of
token budget, exiting.` in the vllm logs on our cluster. The same examples with ollama seem to work fine and do not trigger this message. 

Also, according to https://github.com/meta-llama/llama-models llama 3.2 context length is 128k, not 4096.

So I'd like to increase the limit on our cluster here to see if I'm actually coming up against the vllm imposed limit, or if this error is caused by something else.   