### PR TITLE
making the examples run more cleanly

### DIFF
--- a/prototype/frameworks/llamastack/README.md
+++ b/prototype/frameworks/llamastack/README.md
@@ -131,6 +131,23 @@ python scripts/coding-agent.py
 
 If you wish to test around the web search tool with external web search API, you can follow the example in `scripts/tool_websearch.py`. 
 
+You will need to get a Tavily Search dev API key for this example, from [Tavily Search](https://tavily.com/). Then export it as an environment variable:
+```bash
+export $TAVILY_SEARCH_API_KEY=<your dev API key>
+```
+
+Then modify your podman run command to add the API key:
+```bash
+podman run --privileged -it \
+  -p $LLAMA_STACK_PORT:$LLAMA_STACK_PORT \
+  -v ~/.llama:/root/.llama \
+  --env INFERENCE_MODEL=$INFERENCE_MODEL \
+  --env TAVILY_SEARCH_API_KEY=$TAVILY_SEARCH_API_KEY \
+  --env OLLAMA_URL=http://host.containers.internal:11434 \
+  llamastack/distribution-ollama \
+  --port $LLAMA_STACK_PORT
+```
+
 Run the script:
 
 ```bash

--- a/prototype/frameworks/llamastack/README.md
+++ b/prototype/frameworks/llamastack/README.md
@@ -124,7 +124,7 @@ If you want to execute code using an AI-powered agent, you can follow the exampl
 
 Run the script:
 ```bash
-python scripts/code-agent.py
+python scripts/coding-agent.py
 ```
 ---
 ## **9. Run a build in web search Agent**

--- a/prototype/frameworks/llamastack/README.md
+++ b/prototype/frameworks/llamastack/README.md
@@ -92,7 +92,10 @@ Verify installation:
 ```bash
 pip list | grep llama-stack-client
 ```
-
+Install required libraries:
+```bash
+pip install -r requirements.txt
+```
 ---
 
 ## **6. Configure the Client**

--- a/prototype/frameworks/llamastack/requirements.txt
+++ b/prototype/frameworks/llamastack/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv

--- a/prototype/frameworks/llamastack/requirements.txt
+++ b/prototype/frameworks/llamastack/requirements.txt
@@ -1,1 +1,2 @@
 python-dotenv
+fire

--- a/prototype/frameworks/llamastack/scripts/tool_websearch.py
+++ b/prototype/frameworks/llamastack/scripts/tool_websearch.py
@@ -33,7 +33,7 @@ agent = Agent(
 
 user_prompts = [
     "Hello",
-    "How US performed in the olympics?",
+    "How did the USA perform in the last Olympics?",
 ]
 
 session_id = agent.create_session("test-session")


### PR DESCRIPTION
A few small changes to make the Llama Stack examples run cleanly. 
Added missing libraries.
Updated the Readme to install the libraries.
Explained how to pass in the Tavily search API key.
Fixed a typo.

Tested by running the examples. 