### PR TITLE
Fix URL type issue

### DIFF
--- a/prototype/frameworks/llamastack/scripts/mcp-tool-agent.py
+++ b/prototype/frameworks/llamastack/scripts/mcp-tool-agent.py
@@ -1,7 +1,6 @@
 from llama_stack_client.lib.agents.agent import Agent
 from llama_stack_client.lib.agents.event_logger import EventLogger
 from llama_stack_client.types.agent_create_params import AgentConfig
-from llama_stack_client.types.shared_params.url import URL
 from llama_stack_client import LlamaStackClient
 from termcolor import cprint
 
@@ -30,10 +29,12 @@ client = LlamaStackClient(base_url=base_url)
 
 
 # Register MCP tools
+# If you're running llamastack through conda 
+# then http://localhost:8000/sse will work for mcp_endpoint
 client.toolgroups.register(
     toolgroup_id="mcp::filesystem",
     provider_id="model-context-protocol",
-    mcp_endpoint=URL(uri="http://host.containers.internal:8000/sse"))
+    mcp_endpoint={"uri":"http://host.containers.internal:8000/sse"})
 
 # Define an agent with MCP toolgroup 
 agent_config = AgentConfig(
@@ -46,7 +47,7 @@ agent_config = AgentConfig(
 )
 agent = Agent(client, agent_config)
 user_prompts = [
-    "Fetch content from https://www.google.com and print the response"
+    "Fetch content from https://www.google.com and summarize the response"
 ]
 
 # Run a session with the agent


### PR DESCRIPTION
@amfred this should fix the issue of not finding `from llama_stack_client.types.shared_params.url import URL` 