### PR TITLE
updates typical llama stack port and uses env variables if set

### DIFF
--- a/prototype/frameworks/llamastack/scripts/mcp-tool-agent.py
+++ b/prototype/frameworks/llamastack/scripts/mcp-tool-agent.py
@@ -1,3 +1,4 @@
+import os
 from llama_stack_client.lib.agents.agent import Agent
 from llama_stack_client.lib.agents.event_logger import EventLogger
 from llama_stack_client.types.agent_create_params import AgentConfig
@@ -6,13 +7,14 @@ from termcolor import cprint
 
 ## Start the llama stack server with vLLM backend
 
+# export LLAMA_STACK_PORT=8321
 # podman run \
 #   -it \
-#   -p 5001:5001 \
+#   -p $LLAMA_STACK_PORT:$LLAMA_STACK_PORT \
 #   -v ./run.yaml:/root/my-run.yaml \
 #   llamastack/distribution-remote-vllm \
 #   --yaml-config /root/my-run.yaml \
-#   --port 5001 \
+#   --port $LLAMA_STACK_PORT \
 #   --env INFERENCE_MODEL=meta-llama/Llama-3.2-3B-Instruct \
 #   --env VLLM_URL=xxx
 
@@ -20,10 +22,12 @@ from termcolor import cprint
 # git clone https://github.com/modelcontextprotocol/python-sdk
 # Follow instructions to get the env ready
 # cd examples/servers/simple-tool
-# uv run mcp-simple-tool --transport sse --port 8000
+# export MCP_PORT=8000
+# uv run mcp-simple-tool --transport sse --port $MCP_PORT
 
 # Connect to the llama stack server
-base_url="http://localhost:5001"
+llama_stack_port = os.environ.get("LLAMA_STACK_PORT", "8321")
+base_url=f"http://localhost:{llama_stack_port}"
 model_id="meta-llama/Llama-3.2-3B-Instruct"
 client = LlamaStackClient(base_url=base_url)
 
@@ -31,10 +35,11 @@ client = LlamaStackClient(base_url=base_url)
 # Register MCP tools
 # If you're running llamastack through conda 
 # then http://localhost:8000/sse will work for mcp_endpoint
+mcp_port = os.environ.get("MCP_PORT", "8000")
 client.toolgroups.register(
     toolgroup_id="mcp::filesystem",
     provider_id="model-context-protocol",
-    mcp_endpoint={"uri":"http://host.containers.internal:8000/sse"})
+    mcp_endpoint={"uri":f"http://host.containers.internal:{mcp_port}/sse"})
 
 # Define an agent with MCP toolgroup 
 agent_config = AgentConfig(

--- a/prototype/frameworks/mcp/openapi/README.md
+++ b/prototype/frameworks/mcp/openapi/README.md
@@ -3,4 +3,4 @@
 pip install -r requirements.txt
 
 ### Run the MCP OpenAPI tool server with your remote OpenAPI spec
-python mcp_server.py http://localhost:5001/openapi.json --transport sse
+python mcp_server.py http://localhost:8321/openapi.json --transport sse


### PR DESCRIPTION
The typical llama stack port is 8321 and port 5001 sometimes conflicts with an existing service. 
The readme also recommends setting this as an environment variable, so I modified the code to check for an environment variable if it's set.

Test:
```
python scripts/mcp-tool-agent.py                         
`agent_config` is deprecated. Use inlined parameters instead.
User> Fetch content from https://www.google.com and summarize the response
inference> [fetch(url='https://www.google.com')]
tool_execution> Tool:fetch Args:{'url': 'https://www.google.com'}
tool_execution> Tool:fetch Response:{"type":"text","text":"<!doctype html><html itemscope=\"\" itemtype=\"http://schema.org/WebPage\" lang=\"en\"><head><meta content=\"Search the world's information, including webpages, images, videos and more. Google has many special features to help you find exactly what you're looking for.\" name=\"description\"
```
blah blah
```
inference> The provided code is a JavaScript snippet that appears to be part of the Google Custom Search Engine (CSE) API. It's used for customizing and managing search results from Google. Here's a breakdown of what it does:

1.  **Initialization**: The script initializes various variables, including `pmc` which holds the configuration object for the CSE.
2.  **CSS Installation**: It installs CSS styles to customize the appearance of the search results page.
3.  **Image Lazy Loading**: It enables image lazy loading for faster page loading times.
4.  **Error Handling**: The script handles errors that may occur during the execution of the code, such as network errors or exceptions.
5.  **Custom Search Engine Configuration**: It configures the custom search engine with various settings, including the search query, results format, and more.
```

